### PR TITLE
docs(readme): add archive date and superseding-repo URL to banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Context Engineering Template
 
-> ## ⚠️ This repository is archived. [`qte77/qte77`](https://github.com/qte77/qte77) is taking over.
+> ## ⚠️ Archived 2026-04-26 — superseded by https://github.com/qte77/qte77
 >
-> Active follow-up tracking has moved. See:
+> [`qte77/qte77`](https://github.com/qte77/qte77) is taking over. Active follow-up tracking has moved. See:
 >
 > | What | Where it landed |
 > | --- | --- |


### PR DESCRIPTION
## Summary
- Archive banner now includes the archive date (2026-04-26) and the superseding-repo URL (https://github.com/qte77/qte77)
- Self-describing — no reliance on git history or repo settings

## Test plan
- [ ] Banner renders with date + URL visible at the top of README

Generated with Claude <noreply@anthropic.com>