### PR TITLE
chore(license): align README badge and pyproject metadata to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Business workflow system with AI agent support. Evolving toward intelligent orchestration: from business analysis to requirements to implementation.
 
-[![License](https://img.shields.io/badge/license-GNUGPLv3-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-1.0.0-58f4c2)
 [![CodeQL](https://github.com/qte77/context-engineering-template/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/context-engineering-template/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/context-engineering-template/badge)](https://www.codefactor.io/repository/github/qte77/context-engineering-template)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.13"
-license = "bsd-3-clause"
+license = "Apache-2.0"
 dependencies = []
 
 [project.urls]


### PR DESCRIPTION
## Summary
Pre-archive consistency fix. The canonical LICENSE file is Apache 2.0, but two metadata sources disagreed:

| Source | Was | Now |
| --- | --- | --- |
| LICENSE | Apache 2.0 | (canonical, unchanged) |
| README.md badge | GNUGPLv3 | Apache-2.0 |
| pyproject.toml | bsd-3-clause | Apache-2.0 |

Align all three to Apache-2.0 so the archived snapshot is internally consistent.

## Test plan
- [ ] Render README — license badge shows Apache-2.0
- [ ] `python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['license'])"` returns `Apache-2.0`

Generated with Claude <noreply@anthropic.com>